### PR TITLE
Fix 'NSConcreteValue doubleValue unrecognized selector' crash

### DIFF
--- a/EatFit/Views/DropView.swift
+++ b/EatFit/Views/DropView.swift
@@ -43,7 +43,7 @@ class DropView : UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        drop.frame = CGRect(x: (bounds.width - chartThickness) / 2.0, y: -(chartThickness / 2.0), width: chartThickness, height: chartThickness)
+        drop.frame = CGRect(x: (ceil(bounds.width) - chartThickness) / 2.0, y: -(chartThickness / 2.0), width: chartThickness, height: chartThickness)
         drop.path = UIBezierPath(ovalInRect: drop.bounds).CGPath
         
          logoImageView.frame = CGRect(x: (bounds.width - 30.0) / 2.0, y: -chartThickness, width: 30.0, height: 30.0)


### PR DESCRIPTION
This PR fixes crash #4 that occurs when swiping to the next page if the user waits for the entire animation to finish before doing so.

Steps to reproduce the crash:
1. (Clone the latest version and) launch the demo app
2. Wait for the first page to fully finish animating (until the water icon is visible, essentially)
3. Swipe right

The `drop` CAShapeLayer variable in the `DropView` class crashes when its frame is directly altered in line 44. This happens in the `layoutSubviews` function when the `bounds.width` needs to be expressed as a Double and the app crashes subsequently.

This is a simple fix that performs a `ceil()` on `bounds.width`, thus preventing NSConcreteValue from receiving a double instead of a CGFloat.
